### PR TITLE
Bump numpy 1.12.4 for support apple M1 chip

### DIFF
--- a/dev/dev-requirements.txt
+++ b/dev/dev-requirements.txt
@@ -14,4 +14,4 @@
 # limitations under the License.
 setuptools>=18.0
 wheel
-numpy==1.19.5
+numpy==1.21.4

--- a/setup.py
+++ b/setup.py
@@ -211,7 +211,7 @@ setup(
     license='https://www.apache.org/licenses/LICENSE-2.0',
     author_email='hxbks2ks@gmai.com',
     python_requires='>=3.7',
-    install_requires=['numpy==1.19.5'],
+    install_requires=['numpy==1.21.4'],
     cmdclass={'build_ext': build_ext},
     description='PemJa',
     long_description=long_description,


### PR DESCRIPTION
I have run PythonInterpreterTest class successful.
I want to bump beam in PyFlink, but pemja depends on numpy==1.19.5.
```
The conflict is caused by:
   apache-flink 1.15.dev0 depends on numpy>=1.21.4
   apache-beam 2.36.0 depends on numpy<1.22.0 and >=1.14.3
   pemja 0.1.2 depends on numpy==1.19.5
```
