### PR TITLE
Correct integer usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ PythonInterpreter interpreter = new PythonInterpreter(config);
 // set & get
 interpreter.set("a", 12345);
 interpreter.get("a"); // Object
-interpreter.get("a", int.class); // int
+interpreter.get("a", Integer.class); // Integer
 
 // exec & eval
 interpreter.exec("print(a)");


### PR DESCRIPTION
Call `interpreter.get` with `Integer.class` not `int.class`
Related issue: #20