### PR TITLE
Add windows platform mingw32 compiler support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,8 @@ import os
 import sys
 import sysconfig
 import warnings
-from distutils.command.build_ext import build_ext as old_build_ext
-
 from setuptools import setup, Extension
+from distutils.command.build_ext import build_ext as old_build_ext
 
 if sys.version_info < (3, 7):
     print('Python versions prior to 3.7 are not supported for PemJa.',
@@ -77,6 +76,8 @@ def is_osx():
 def is_bsd():
     return 'bsd' in sysconfig.get_platform()
 
+def is_windows():
+    return 'win' in sysconfig.get_platform()
 
 def get_python_libs():
     libs = []
@@ -103,6 +104,33 @@ def get_java_linker_args():
         return ['-framework JavaVM']
     return []
 
+def get_java_libraries():
+    if is_windows():
+        return ['jvm']
+    return []
+
+def get_java_lib_folders():
+    if not is_osx():
+        import fnmatch
+        if is_windows():
+            jre = os.path.join(get_java_home(), 'lib')
+        else:
+            jre = os.path.join(get_java_home(), 'jre', 'lib')
+            if not os.path.exists(jre):
+                jre = os.path.join(get_java_home(), 'lib')
+        folders = []
+        for root, dirnames, filenames in os.walk(jre):
+            if is_windows():
+                for filename in fnmatch.filter(filenames, '*jvm.lib'):
+                    folders.append(os.path.join(
+                        root, os.path.dirname(filename)))
+            else:
+                for filename in fnmatch.filter(filenames, '*jvm.so'):
+                    folders.append(os.path.join(
+                        root, os.path.dirname(filename)))
+
+        return list(set(folders))
+    return []
 
 def get_java_include():
     inc_name = 'include'
@@ -131,6 +159,10 @@ def get_java_include():
     include_darwin = os.path.join(inc, 'darwin')
     if os.path.exists(include_darwin):
         paths.append(include_darwin)
+
+    include_win32 = os.path.join(inc, 'win32')
+    if os.path.exists(include_win32):
+        paths.append(include_win32)
 
     include_bsd = os.path.join(inc, 'freebsd')
     if os.path.exists(include_bsd):
@@ -163,13 +195,15 @@ extensions = ([
     Extension(
         name="pemja_core",
         sources=get_files('src/main/c/pemja/core', '.c'),
-        libraries=get_python_libs(),
+        libraries=get_java_libraries() + get_python_libs(),
+        library_dirs = get_java_lib_folders(),
         extra_link_args=get_java_linker_args(),
         include_dirs=get_java_include() + ['src/main/c/pemja/core/include'],
         language=3),
     Extension(
         name="pemja_utils",
         sources=get_files('src/main/c/pemja/utils', '.c'),
+        library_dirs = get_java_lib_folders(),
         extra_link_args=get_java_linker_args(),
         include_dirs=get_java_include() + ['src/main/c/pemja/utils/include'],
         language=3)

--- a/src/main/c/pemja/core/PythonInterpreter.c
+++ b/src/main/c/pemja/core/PythonInterpreter.c
@@ -17,6 +17,14 @@
 #include "MainInterpreter.h"
 #include "PythonInterpreter.h"
 
+// use windows mingw32
+#if (defined(_WIN32) || defined(_WIN64)) && defined(__MINGW32__)
+    PyMODINIT_FUNC PyInit_pemja_core(void) {
+        // pass
+    }
+#else
+#endif
+
 // ---------------------------------- jni functions ------------------------
 
 

--- a/src/main/c/pemja/utils/CommonUtils.c
+++ b/src/main/c/pemja/utils/CommonUtils.c
@@ -12,8 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include <stdlib.h>
-#include <dlfcn.h>
 #include <CommonUtils.h>
+
+#if (defined(_WIN32) || defined(_WIN64)) && defined(__MINGW32__)
+    #include <windows.h>
+    #include <Python.h>
+    PyMODINIT_FUNC PyInit_pemja_utils(void) {
+        // pass
+    }
+#else
+    // linux and macos
+    #include <dlfcn.h>
+#endif
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved)
@@ -29,17 +39,28 @@ JNI_OnLoad(JavaVM *vm, void *reserved)
 JNIEXPORT void JNICALL Java_pemja_utils_CommonUtils_loadLibrary0
   (JNIEnv *env, jobject obj, jstring library)
 {
-    void* dlresult = dlopen((*env)->GetStringUTFChars(env, library, 0), RTLD_NOW | RTLD_GLOBAL);
-    if (dlresult) {
-        // The dynamic linker maintains reference counts so closing it is a no-op.
-        dlclose(dlresult);
-    } else {
-        /*
-         * Ignore errors and hope that the library is loaded globally or the
-         * extensions are linked. If developers need to debug the cause they
-         * should print the result of dlerror.
-         */
-        fprintf(stderr, "%s\n", dlerror());
-        exit(EXIT_FAILURE);
-    }
+    char* fileName = (*env)->GetStringUTFChars(env, library, 0);
+    #if (defined(_WIN32) || defined(_WIN64))
+        HINSTANCE dlresult = LoadLibrary(fileName);
+        if (dlresult) {
+            FreeLibrary(dlresult);
+        } else {
+            fprintf(stderr, "load dll failed. 0x%x\n", GetLastError());
+            exit(EXIT_FAILURE);
+        }
+    #else
+        void* dlresult = dlopen(fileName, RTLD_NOW | RTLD_GLOBAL);
+        if (dlresult) {
+            // The dynamic linker maintains reference counts so closing it is a no-op.
+            dlclose(dlresult);
+        } else {
+            /*
+             * Ignore errors and hope that the library is loaded globally or the
+             * extensions are linked. If developers need to debug the cause they
+             * should print the result of dlerror.
+             */
+            fprintf(stderr, "%s\n", dlerror());
+            exit(EXIT_FAILURE);
+        }
+    #endif
 }


### PR DESCRIPTION
Add windows platform mingw32 compiler support.

now you can use the following command to compile on windows:
```
python3.exe setup.py build --compiler=mingw32
```

About the mingw compiler can be found here: [winlibs](https://winlibs.com/)
```

```