### PR TITLE
README highlight Python v3.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Prerequisites for building PemJa:
 * Git
 * Maven (we recommend version 3.2.5 and require at least 3.1.1)
 * Java 8 or 11 (Java 9 or 10 may work)
-* Python >= 3.7 (we recommend version 3.7, 3.8, 3.9)
+* Python >= 3.7 (we recommend version 3.7-3.10)
 
 ```
 git clone https://github.com/alibaba/pemja.git


### PR DESCRIPTION
Following https://github.com/alibaba/pemja/pull/28 Python 3.10 is fully tested Updating README to reflect this