### PR TITLE
Supported custom define python home on pythonInterpreter

### DIFF
--- a/src/main/c/pemja/core/PythonInterpreter.c
+++ b/src/main/c/pemja/core/PythonInterpreter.c
@@ -55,9 +55,9 @@ JNI_OnUnload(JavaVM *vm, void *reserved)
  * Signature: (V)V
  */
 JNIEXPORT void JNICALL Java_pemja_core_PythonInterpreter_00024MainInterpreter_initialize
-  (JNIEnv *env, jobject obj)
+  (JNIEnv *env, jobject obj, jstring pythonInterpreterPath)
 {
-    JcpPy_Initialize(env);
+    JcpPy_Initialize(env, pythonInterpreterPath);
 }
 
 /*

--- a/src/main/c/pemja/core/include/MainInterpreter.h
+++ b/src/main/c/pemja/core/include/MainInterpreter.h
@@ -27,7 +27,7 @@ extern "C" {
  * Signature: (V)V
  */
 JNIEXPORT void JNICALL Java_pemja_core_PythonInterpreter_00024MainInterpreter_initialize
-  (JNIEnv *, jobject);
+  (JNIEnv *, jobject, jstring);
 
 /*
  * Class:     pemja_core_PythonInterpreter_MainInterpreter

--- a/src/main/c/pemja/core/include/pylib.h
+++ b/src/main/c/pemja/core/include/pylib.h
@@ -64,7 +64,7 @@ JcpAPI_FUNC(JNIEnv*) JcpThreadEnv_Get(void);
 
 
 /* Initialization and finalization */
-JcpAPI_FUNC(void) JcpPy_Initialize(JNIEnv *);
+JcpAPI_FUNC(void) JcpPy_Initialize(JNIEnv *, jstring);
 JcpAPI_FUNC(void) JcpPy_Finalize(JavaVM *);
 JcpAPI_FUNC(intptr_t) JcpPy_InitThread(JNIEnv *, int);
 JcpAPI_FUNC(void) JcpPy_FinalizeThread(intptr_t);

--- a/src/main/c/pemja/core/pylib.c
+++ b/src/main/c/pemja/core/pylib.c
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "Pemja.h"
+#include "wchar.h"
 
 #include "python_class/PythonClass.h"
 #include "java_class/JavaClass.h"
@@ -277,7 +278,7 @@ pyjtypes_init()
 }
 
 void
-JcpPy_Initialize(JNIEnv *env)
+JcpPy_Initialize(JNIEnv *env, jstring pythonInterpreterPath)
 {
 
     PyObject* sys_modules        = NULL;
@@ -290,6 +291,14 @@ JcpPy_Initialize(JNIEnv *env)
 
     // Cache java classes
     Jcp_CacheClasses(env);
+
+    if (pythonInterpreterPath != NULL) {
+        const char* python_interpreter_path = JcpString_FromJString(env, pythonInterpreterPath);
+        size_t len = mbstowcs(NULL, python_interpreter_path, 0);
+        wchar_t* wstr = malloc((len + 1) * sizeof(wchar_t));
+        mbstowcs(wstr, python_interpreter_path, len + 1);
+        Py_SetPythonHome(wstr);
+    }
 
     // Initialize Python
     Py_Initialize();

--- a/src/main/java/pemja/core/PythonInterpreter.java
+++ b/src/main/java/pemja/core/PythonInterpreter.java
@@ -142,7 +142,7 @@ public final class PythonInterpreter implements Interpreter {
      * @param config the specified {@link PythonInterpreterConfig}.
      */
     private void initialize(PythonInterpreterConfig config) {
-        mainInterpreter.initialize(config.getPythonExec());
+        mainInterpreter.initializeInterpreter(config.getPythonExec(), config.getPythonHome());
         this.tState = init(config.getExecType().ordinal());
 
         synchronized (PythonInterpreter.class) {
@@ -350,7 +350,7 @@ public final class PythonInterpreter implements Interpreter {
 
         /** Initializes CPython. */
         @SuppressWarnings("unchecked")
-        synchronized void initialize(String pythonExec) {
+        synchronized void initializeInterpreter(String pythonExec, String pythonHome) {
             if (!isStarted) {
                 String pemjaLibPath =
                         CommonUtils.INSTANCE.getLibraryPathWithPattern(
@@ -397,7 +397,7 @@ public final class PythonInterpreter implements Interpreter {
                             @Override
                             public void run() {
                                 try {
-                                    initialize();
+                                    initialize(pythonHome);
                                     // add shared modules
                                     addToPath(pemjaModulePath);
                                     importModule("redirect_stream");
@@ -440,7 +440,7 @@ public final class PythonInterpreter implements Interpreter {
         }
 
         /** Initialize Python Interpreter. */
-        private native void initialize();
+        private native void initialize(String pythonInterpreterPath);
 
         /** Adds the search path to the main interpreter. */
         private native void addToPath(String path);

--- a/src/main/java/pemja/core/PythonInterpreterConfig.java
+++ b/src/main/java/pemja/core/PythonInterpreterConfig.java
@@ -50,10 +50,14 @@ public final class PythonInterpreterConfig {
     /** Defines the execution type of python interpreter. */
     private final ExecType execType;
 
-    private PythonInterpreterConfig(String[] paths, String pythonExec, ExecType execType) {
+    /** Defines whether the python interpreter is custom. */
+    private final String pythonHome;
+
+    private PythonInterpreterConfig(String[] paths, String pythonExec, ExecType execType, String pythonHome) {
         this.paths = paths;
         this.pythonExec = pythonExec;
         this.execType = execType;
+        this.pythonHome = pythonHome;
     }
 
     /** Returns the search paths. */
@@ -71,6 +75,11 @@ public final class PythonInterpreterConfig {
         return execType;
     }
 
+    /** Returns the isCustom of python interpreter. */
+    public String getPythonHome() {
+        return pythonHome;
+    }
+
     /** A builder for configuring the {@link PythonInterpreterConfig}. */
     public static PythonInterpreterConfigBuilder newBuilder() {
         return new PythonInterpreterConfigBuilder();
@@ -82,6 +91,8 @@ public final class PythonInterpreterConfig {
         private String pythonExec = null;
 
         private ExecType execType = ExecType.MULTI_THREAD;
+
+        private String pythonHome = null;
 
         /**
          * Adds the search paths for module files. One or more directory path names separated by
@@ -140,9 +151,15 @@ public final class PythonInterpreterConfig {
             return this;
         }
 
+        /** Configures whether the python interpreter is custom. */
+        public PythonInterpreterConfigBuilder setPythonHome(String pythonHome) {
+            this.pythonHome = pythonHome;
+            return this;
+        }
+
         /** Creates the actual {@link PythonInterpreterConfig}. */
         public PythonInterpreterConfig build() {
-            return new PythonInterpreterConfig(paths.toArray(new String[0]), pythonExec, execType);
+            return new PythonInterpreterConfig(paths.toArray(new String[0]), pythonExec, execType, pythonHome);
         }
     }
 

--- a/src/main/java/pemja/utils/CommonUtils.java
+++ b/src/main/java/pemja/utils/CommonUtils.java
@@ -42,6 +42,9 @@ public class CommonUtils {
     private static final String GET_PEMJA_MODULE_PATH_SCRIPT =
             "import pemja;" + "import os;" + "print(os.path.dirname(pemja.__file__))";
 
+    private static final String GET_PYTHON_HOME_SCRIPT =
+            "import sys; print(sys.prefix)";
+
     private CommonUtils() {}
 
     /**
@@ -153,6 +156,21 @@ public class CommonUtils {
             return String.join(File.pathSeparator, out.trim().split("\n"));
         } catch (IOException e) {
             throw new RuntimeException("Failed to find libpython", e);
+        }
+    }
+
+    public String getPythonHome(String pythonExec) {
+        try {
+            String out;
+            if (pythonExec == null) {
+                // run in source code, use default `python3` to find python lib library.
+                out = execute(new String[] {"python3", "-c", GET_PYTHON_LIB_PATH_SCRIPT});
+            } else {
+                out = execute(new String[] {pythonExec, "-c", GET_PYTHON_LIB_PATH_SCRIPT});
+            }
+            return String.join(File.pathSeparator, out.trim().split("\n"));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to find python home", e);
         }
     }
 


### PR DESCRIPTION
When specifying a manually packaged Python environment, a ModuleNotFoundError exception may occur. This error can be avoided by setting the PYTHONHOME environment variable.

![image](https://github.com/user-attachments/assets/755927f6-1858-4c88-bb25-c84fd6079911)
