### PR TITLE
detect Python command name to support debugging pemja with IntelliJ IDEA under Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .classpath
 *.jar
 .idea/*
+.venv/*
 *.pyc
+*.pyd
 .DS_Store
 dist/
 build/

--- a/src/main/java/pemja/utils/CommonUtils.java
+++ b/src/main/java/pemja/utils/CommonUtils.java
@@ -145,8 +145,8 @@ public class CommonUtils {
         try {
             String out;
             if (pythonExec == null) {
-                // run in source code, use default `python3` to find python lib library.
-                out = execute(new String[] {"python3", "-c", GET_PYTHON_LIB_PATH_SCRIPT});
+                // run in source code, use default `python3` / `python` to find python lib library.
+                out = execute(new String[] {getPythonCommand(), "-c", GET_PYTHON_LIB_PATH_SCRIPT});
             } else {
                 out = execute(new String[] {pythonExec, "-c", GET_PYTHON_LIB_PATH_SCRIPT});
             }
@@ -159,6 +159,15 @@ public class CommonUtils {
     public boolean isLinuxOs() {
         String os = System.getProperty("os.name");
         return os.startsWith("Linux");
+    }
+
+    public boolean isWindowsOs() {
+        String os = System.getProperty("os.name");
+        return os.startsWith("Windows");
+    }
+
+    public String getPythonCommand() {
+        return isWindowsOs() ? "python" : "python3";
     }
 
     private String execute(String[] commands) throws IOException {


### PR DESCRIPTION
通过简单修改检测 Python 可执行文件的名字，并正确设置调试环境，在 Windows 10 下的 IntelliJ IDEA 中成功运行了 pemja 的全部测试。效果图见 2 楼，详细的操作步骤见 3 楼。