### PR TITLE
Load pemja library error in centos #64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -200,20 +200,20 @@ class build_ext(old_build_ext):
 
 extensions = ([
     Extension(
-        name="pemja_core",
+        name="pemja.pemja_core",
         sources=get_files('src/main/c/pemja/core', '.c'),
         libraries=get_java_libraries() + get_python_libs(),
         library_dirs = get_java_lib_folders(),
         extra_link_args=get_java_linker_args(),
         include_dirs=get_java_include() + ['src/main/c/pemja/core/include'],
-        language="3"),
+        language="c"),
     Extension(
-        name="pemja_utils",
+        name="pemja.pemja_utils",
         sources=get_files('src/main/c/pemja/utils', '.c'),
         library_dirs = get_java_lib_folders(),
         extra_link_args=get_java_linker_args(),
         include_dirs=get_java_include() + ['src/main/c/pemja/utils/include'],
-        language="3")
+        language="c")
 ])
 
 PACKAGE_DATA = {

--- a/src/main/java/pemja/utils/CommonUtils.java
+++ b/src/main/java/pemja/utils/CommonUtils.java
@@ -35,9 +35,6 @@ public class CommonUtils {
     private static final String GET_PYTHON_LIB_PATH_SCRIPT =
             "from find_libpython import find_libpython;" + "print(find_libpython())";
 
-    private static final String GET_SITE_PACKAGES_PATH_SCRIPT =
-            "import sysconfig; print(sysconfig.get_paths()['purelib'])";
-
     private static final String GET_PEMJA_MODULE_PATH_SCRIPT =
             "import pemja;" + "import os;" + "print(os.path.dirname(pemja.__file__))";
 
@@ -117,7 +114,8 @@ public class CommonUtils {
                             System.getProperty("user.dir"),
                             "src",
                             "main",
-                            "python");
+                            "python",
+                            "pemja");
             File pythonModuleFile = new File(pythonModulePath);
             for (File f : Objects.requireNonNull(pythonModuleFile.listFiles())) {
                 if (f.isFile() && Pattern.matches(pattern, f.getName())) {
@@ -131,8 +129,7 @@ public class CommonUtils {
         } else {
             String sitePackagesPath;
             try {
-                String out =
-                        execute(new String[] {pythonExec, "-c", GET_SITE_PACKAGES_PATH_SCRIPT});
+                String out = execute(new String[] {pythonExec, "-c", GET_PEMJA_MODULE_PATH_SCRIPT});
                 sitePackagesPath = String.join(File.pathSeparator, out.trim().split("\n"));
             } catch (IOException e) {
                 throw new RuntimeException(


### PR DESCRIPTION
In centOS, 

<img width="2069" alt="Clipboard_Screenshot_1748933196" src="https://github.com/user-attachments/assets/db79b4fd-d6ea-489f-867d-0b27ae192d80" />
when using sysconfig.get_paths()['purelib'], this path contains only the python dependency, and the `.so|.pyd` can not be found in this path. Even using sysconfig.get_paths()['platlib']. Because in centos, The system will preferentially download to the /usr/local/lib64/python-xx/site-package folder when using `pip install xx`.