### PR TITLE
[BP] Sync release-0.6 fixes to main

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,7 @@ on:
     - cron: '10 2 * * *'
   push:
     branches: [ '*' ]
+    tags: [ 'release*' ]
   pull_request:
     branches:
       - main

--- a/src/main/c/pemja/core/pylib.c
+++ b/src/main/c/pemja/core/pylib.c
@@ -188,10 +188,6 @@ JcpThread *JcpThread_Get(void) {
     }
   }
   Py_XDECREF(key);
-  if (!ret && !PyErr_Occurred()) {
-    PyErr_Format(PyExc_RuntimeError,
-                 "No JcpThread instance available on current thread.");
-  }
   return ret;
 }
 

--- a/src/main/c/pemja/core/python_class/pyjobject.c
+++ b/src/main/c/pemja/core/python_class/pyjobject.c
@@ -39,11 +39,18 @@ static int pyjobject_init(JNIEnv *env, PyJObject *self) {
   self->class_name = JcpPyString_FromJString(env, className);
   jcpThread = JcpThread_Get();
 
-  if (jcpThread->name_to_attrs == NULL) {
-    jcpThread->name_to_attrs = PyDict_New();
+  if (jcpThread != NULL) {
+    if (jcpThread->name_to_attrs == NULL) {
+      jcpThread->name_to_attrs = PyDict_New();
+    }
+    cachedAttrs = PyDict_GetItem(jcpThread->name_to_attrs, self->class_name);
+  } else {
+    // On non-pemja threads (e.g., Python async threads), no JcpThread is
+    // available. Clear the error set by JcpThread_Get() and proceed without
+    // the per-thread attribute cache.
+    PyErr_Clear();
+    cachedAttrs = NULL;
   }
-
-  cachedAttrs = PyDict_GetItem(jcpThread->name_to_attrs, self->class_name);
 
   if (cachedAttrs == NULL) {
     cachedAttrs = PyDict_New();
@@ -125,8 +132,12 @@ static int pyjobject_init(JNIEnv *env, PyJObject *self) {
     }
     (*env)->DeleteLocalRef(env, fields);
 
-    PyDict_SetItem(jcpThread->name_to_attrs, self->class_name, cachedAttrs);
-    Py_DECREF(cachedAttrs);
+    if (jcpThread != NULL) {
+      PyDict_SetItem(jcpThread->name_to_attrs, self->class_name, cachedAttrs);
+      Py_DECREF(cachedAttrs);
+    }
+    // When jcpThread is NULL, we still own the ref from PyDict_New().
+    // It will be balanced by the Py_DECREF after self->attr assignment below.
   }
 
   if (self->object) {
@@ -134,6 +145,12 @@ static int pyjobject_init(JNIEnv *env, PyJObject *self) {
     self->attr = cachedAttrs;
   } else {
     self->attr = PyDict_Copy(cachedAttrs);
+  }
+
+  // When there is no JcpThread, no cache holds a reference to cachedAttrs,
+  // so we must release the owned ref from PyDict_New() here.
+  if (jcpThread == NULL) {
+    Py_DECREF(cachedAttrs);
   }
 
   (*env)->PopLocalFrame(env, NULL);

--- a/src/main/java/pemja/core/PythonInterpreter.java
+++ b/src/main/java/pemja/core/PythonInterpreter.java
@@ -362,7 +362,7 @@ public final class PythonInterpreter implements Interpreter {
         /** Initializes CPython. */
         synchronized void initialize(PythonInterpreterConfig config) {
             if (!isStarted) {
-                CommonUtils.INSTANCE.loadPython(config.getPythonExec());
+                CommonUtils.INSTANCE.loadPython(config.getPythonExec(), config.getPaths());
 
                 // We load on a separate thread to try and avoid GIL issues that come about from a
                 // being on the same thread as the main interpreter.
@@ -376,7 +376,7 @@ public final class PythonInterpreter implements Interpreter {
                                     // add shared modules
                                     addToPath(
                                             CommonUtils.INSTANCE.getPemJaModulePath(
-                                                    config.getPythonExec()));
+                                                    config.getPythonExec(), config.getPaths()));
                                     importModule("redirect_stream");
                                 } catch (Throwable t) {
                                     error = t;

--- a/src/main/java/pemja/utils/CommonUtils.java
+++ b/src/main/java/pemja/utils/CommonUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Vector;
@@ -41,17 +42,26 @@ public class CommonUtils {
     private CommonUtils() {}
 
     public void loadPython(String pythonExec) {
-        String pythonLibPath = getPythonLibrary(pythonExec);
+        loadPython(pythonExec, null);
+    }
+
+    public void loadPython(String pythonExec, String[] pythonPaths) {
+        String pythonLibPath = getPythonLibrary(pythonExec, pythonPaths);
         loadLibrary(pythonLibPath, "libpython");
-        loadPythonLibrary(pythonExec, "pemja_utils");
+        loadPythonLibrary(pythonExec, pythonPaths, "pemja_utils");
         // Because JVM can't load library globally, so we need to load CPython library globally.
         loadLibrary0(pythonLibPath);
-        loadPythonLibrary(pythonExec, "pemja_core");
+        loadPythonLibrary(pythonExec, pythonPaths, "pemja_core");
     }
 
     public String getPemJaModulePath(String pythonExec) {
+        return getPemJaModulePath(pythonExec, null);
+    }
+
+    public String getPemJaModulePath(String pythonExec, String[] pythonPaths) {
         if (pythonExec == null) {
-            // run in source code
+            // run in source code — the module path is resolved from the working directory,
+            // no subprocess is launched, so pythonPaths is not applicable here.
             return String.join(
                     File.separator,
                     System.getProperty("user.dir"),
@@ -62,7 +72,10 @@ public class CommonUtils {
         } else {
             String out;
             try {
-                out = execute(new String[] {pythonExec, "-c", GET_PEMJA_MODULE_PATH_SCRIPT});
+                out =
+                        execute(
+                                new String[] {pythonExec, "-c", GET_PEMJA_MODULE_PATH_SCRIPT},
+                                pythonPaths);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to get PemJa module path", e);
             }
@@ -70,10 +83,11 @@ public class CommonUtils {
         }
     }
 
-    private void loadPythonLibrary(String pythonExec, String packageName) {
+    private void loadPythonLibrary(String pythonExec, String[] pythonPaths, String packageName) {
         String packageLibPath =
                 getLibraryPathWithPattern(
                         pythonExec,
+                        pythonPaths,
                         String.format("^%s\\.(cpython-.*\\.so|cp.*-win.*\\.pyd)$", packageName));
         loadLibrary(packageLibPath, packageName);
     }
@@ -105,9 +119,11 @@ public class CommonUtils {
         }
     }
 
-    private String getLibraryPathWithPattern(String pythonExec, String pattern) {
+    private String getLibraryPathWithPattern(
+            String pythonExec, String[] pythonPaths, String pattern) {
         if (pythonExec == null) {
-            // run in source code
+            // run in source code — the library is located by scanning the local filesystem,
+            // no subprocess is launched, so pythonPaths is not applicable here.
             String pythonModulePath =
                     String.join(
                             File.separator,
@@ -129,7 +145,10 @@ public class CommonUtils {
         } else {
             String sitePackagesPath;
             try {
-                String out = execute(new String[] {pythonExec, "-c", GET_PEMJA_MODULE_PATH_SCRIPT});
+                String out =
+                        execute(
+                                new String[] {pythonExec, "-c", GET_PEMJA_MODULE_PATH_SCRIPT},
+                                pythonPaths);
                 sitePackagesPath = String.join(File.pathSeparator, out.trim().split("\n"));
             } catch (IOException e) {
                 throw new RuntimeException(
@@ -147,14 +166,20 @@ public class CommonUtils {
         }
     }
 
-    private String getPythonLibrary(String pythonExec) {
+    private String getPythonLibrary(String pythonExec, String[] pythonPaths) {
         try {
             String out;
             if (pythonExec == null) {
                 // run in source code, use default `python3` / `python` to find python lib library.
-                out = execute(new String[] {getPythonCommand(), "-c", GET_PYTHON_LIB_PATH_SCRIPT});
+                out =
+                        execute(
+                                new String[] {getPythonCommand(), "-c", GET_PYTHON_LIB_PATH_SCRIPT},
+                                pythonPaths);
             } else {
-                out = execute(new String[] {pythonExec, "-c", GET_PYTHON_LIB_PATH_SCRIPT});
+                out =
+                        execute(
+                                new String[] {pythonExec, "-c", GET_PYTHON_LIB_PATH_SCRIPT},
+                                pythonPaths);
             }
             return String.join(File.pathSeparator, out.trim().split("\n"));
         } catch (IOException e) {
@@ -162,9 +187,22 @@ public class CommonUtils {
         }
     }
 
-    private String execute(String[] commands) throws IOException {
+    private String execute(String[] commands, String[] pythonPaths) throws IOException {
         ProcessBuilder pb = new ProcessBuilder(commands);
         pb.redirectErrorStream(true);
+
+        // Set PYTHONPATH environment variable if pythonPaths is provided
+        if (pythonPaths != null && pythonPaths.length > 0) {
+            String pythonPath = String.join(File.pathSeparator, pythonPaths);
+            Map<String, String> env = pb.environment();
+            // Prepend to existing PYTHONPATH if it exists
+            String existingPythonPath = env.get("PYTHONPATH");
+            if (existingPythonPath != null && !existingPythonPath.isEmpty()) {
+                pythonPath = pythonPath + File.pathSeparator + existingPythonPath;
+            }
+            env.put("PYTHONPATH", pythonPath);
+        }
+
         Process p = pb.start();
         InputStream in = new BufferedInputStream(p.getInputStream());
         StringBuilder out = new StringBuilder();

--- a/src/main/python/pemja/logger.py
+++ b/src/main/python/pemja/logger.py
@@ -43,15 +43,12 @@ def _map_log_level(level: int) -> str:
 class PythonLogHandler(logging.Handler):
     def __init__(self):
         super().__init__()
-        self._logger_writer = None
+        from pemja import findClass
+
+        PythonLogWriter = findClass("pemja.core.log.PythonLogWriter")
+        self._logger_writer = PythonLogWriter()
 
     def emit(self, record: logging.LogRecord):
-        if self._logger_writer is None:
-            from pemja import findClass
-
-            PythonLogWriter = findClass("pemja.core.log.PythonLogWriter")
-            self._logger_writer = PythonLogWriter()
-
         message = self.format(record)
         name = "%s:%s" % (
             record.pathname or record.module,

--- a/src/main/python/pemja/tests/test_async_thread.py
+++ b/src/main/python/pemja/tests/test_async_thread.py
@@ -1,0 +1,103 @@
+################################################################################
+#
+#  Copyright 2022 Alibaba Group Holding Limited.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+import asyncio
+import threading
+
+
+# ---------------------------------------------------------------------------
+#  asyncio tests — the event loop runs on a non-pemja thread
+# ---------------------------------------------------------------------------
+
+def test_return_custom_object_in_asyncio(java_obj):
+    """
+    Test that calling a Java method which returns a custom Java object
+    from an asyncio event loop (running on a non-pemja thread) does not
+    crash the JVM.
+
+    Before the fix: SIGSEGV in JcpPyJObject_New (NULL deref on JcpThread).
+    After the fix: works normally.
+    """
+    result = [None]
+    error = [None]
+
+    async def coro():
+        # This runs on the event loop thread (a non-pemja thread).
+        # returnSelf() returns a custom Java object (TestObject), which
+        # goes through JcpPyJObject_New -> pyjobject_init -> JcpThread_Get().
+        obj = java_obj.returnSelf()
+        return str(obj)
+
+    def run_loop():
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            result[0] = loop.run_until_complete(coro())
+            loop.close()
+        except Exception as e:
+            error[0] = str(e)
+
+    t = threading.Thread(target=run_loop)
+    t.start()
+    t.join(timeout=10)
+
+    if error[0] is not None:
+        raise RuntimeError("Error in asyncio thread: " + error[0])
+
+    return result[0]
+
+
+def test_return_string_in_asyncio(java_obj):
+    """
+    Control: returning a String (built-in type) from asyncio should always
+    work, even without the fix.
+    """
+    result = [None]
+    error = [None]
+
+    async def coro():
+        return java_obj.returnString()
+
+    def run_loop():
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            result[0] = loop.run_until_complete(coro())
+            loop.close()
+        except Exception as e:
+            error[0] = str(e)
+
+    t = threading.Thread(target=run_loop)
+    t.start()
+    t.join(timeout=10)
+
+    if error[0] is not None:
+        raise RuntimeError("Error in asyncio thread: " + error[0])
+
+    return result[0]
+
+
+# ---------------------------------------------------------------------------
+#  Same-thread control test
+# ---------------------------------------------------------------------------
+
+def test_return_custom_object_in_same_thread(java_obj):
+    """
+    Control: calling on the pemja thread itself should always work.
+    """
+    obj = java_obj.returnSelf()
+    return str(obj)

--- a/src/test/java/pemja/core/PythonInterpreterTest.java
+++ b/src/test/java/pemja/core/PythonInterpreterTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 /** Tests for {@link PythonInterpreter}. */
 public class PythonInterpreterTest {
@@ -995,5 +996,44 @@ public class PythonInterpreterTest {
             Files.deleteIfExists(file.toPath());
         }
         // else: already deleted
+    }
+
+    /**
+     * Test that pythonPaths is used when executing Python subprocess to find libpython. This tests
+     * the fix for issue #94 where pythonPaths was not being used when initializing the Python
+     * interpreter, causing "ModuleNotFoundError: No module named 'find_libpython'" when
+     * find_libpython was installed in a custom path.
+     */
+    @Test
+    public void testPythonPathsUsedInSubprocessExecution() throws IOException {
+        // Create a temporary directory with a unique test module
+        File customPath = new File(tmpDirPath, "custom_python_path");
+        if (!customPath.mkdirs()) {
+            throw new RuntimeException("Failed to create custom python path directory");
+        }
+
+        // Create a unique test module that doesn't exist in standard Python paths
+        String uniqueModuleName =
+                "pemja_test_unique_module_" + UUID.randomUUID().toString().replace("-", "");
+        File moduleFile = new File(customPath, uniqueModuleName + ".py");
+        Files.write(moduleFile.toPath(), "test_value = 'hello_from_custom_path'\n".getBytes());
+
+        // Test: With pythonPaths, the module should be importable
+        PythonInterpreterConfig config =
+                PythonInterpreterConfig.newBuilder()
+                        .addPythonPaths(customPath.getAbsolutePath())
+                        .build();
+        try (PythonInterpreter interpreter = new PythonInterpreter(config)) {
+            // Import the module - this would fail if pythonPaths was not properly used
+            interpreter.exec("import " + uniqueModuleName);
+            // Verify the module was loaded correctly by accessing the variable
+            interpreter.exec("result_value = " + uniqueModuleName + ".test_value");
+            String result = interpreter.get("result_value", String.class);
+            assertNotNull(result);
+            assertEquals("hello_from_custom_path", result);
+        } finally {
+            // Clean up the temporary directory and its contents
+            deleteDirectory(customPath);
+        }
     }
 }

--- a/src/test/java/pemja/core/PythonInterpreterTest.java
+++ b/src/test/java/pemja/core/PythonInterpreterTest.java
@@ -363,6 +363,36 @@ public class PythonInterpreterTest {
     }
 
     @Test
+    public void testCustomObjectInAsyncThread() {
+        PythonInterpreterConfig config =
+                PythonInterpreterConfig.newBuilder().addPythonPaths(testDir).build();
+        try (PythonInterpreter interpreter = new PythonInterpreter(config)) {
+            interpreter.exec("import test_async_thread");
+
+            TestObject obj = new TestObject();
+
+            // Control: returning String from asyncio should always work
+            Object stringResult =
+                    interpreter.invoke("test_async_thread.test_return_string_in_asyncio", obj);
+            assertEquals("hello from java", stringResult);
+
+            // Control: returning custom object on pemja thread should always work
+            Object sameThreadResult =
+                    interpreter.invoke(
+                            "test_async_thread.test_return_custom_object_in_same_thread", obj);
+            assertNotNull(sameThreadResult);
+
+            // This is the bug scenario: returning a custom Java object from
+            // an asyncio event loop (non-pemja thread). Without the fix, this
+            // crashes the JVM with SIGSEGV in JcpPyJObject_New.
+            Object asyncResult =
+                    interpreter.invoke(
+                            "test_async_thread.test_return_custom_object_in_asyncio", obj);
+            assertNotNull(asyncResult);
+        }
+    }
+
+    @Test
     public void testCallPyJObject() {
         PythonInterpreterConfig config =
                 PythonInterpreterConfig.newBuilder().addPythonPaths(testDir).build();
@@ -927,6 +957,16 @@ public class PythonInterpreterTest {
         public String testJavaCallPython(Interpreter interpreter) {
             interpreter.exec("a = 'testJavaCallPython'");
             return interpreter.get("a", String.class);
+        }
+        /* -------------------------------------------------------------------------------------- */
+
+        /* ----------------------------------- test return custom object ----------------------- */
+        public TestObject returnSelf() {
+            return this;
+        }
+
+        public String returnString() {
+            return "hello from java";
         }
         /* -------------------------------------------------------------------------------------- */
     }


### PR DESCRIPTION
## Summary

Bring the fixes merged into `release-0.6` in #98 forward to `main`: initialize the Java logger before native Python threads emit logs, pass configured Python paths to discovery subprocesses, and handle custom Java objects on Python-created threads without dereferencing a missing `JcpThread`. Also enable wheel builds for release tags.

Cherry-pick the four missing commits individually with source references. The existing initialization-order and aarch64 build changes are already on `main`. Keep `main` at 0.7 and retain its Central Publishing configuration; these are the only remaining file differences from `release-0.6`.

## Validation

- `git diff --check` and `mvn -o validate` passed.
- Native extensions built successfully with CPython 3.13 and JDK 11 on macOS ARM64.
- Individually ran `testCustomObjectInAsyncThread`, `testPythonPathsUsedInSubprocessExecution`, and `testCallbackJavaInMultiThread` successfully.
- Commit comparison confirms unchanged source patches, with only additional cherry-pick provenance in the messages.
- The existing pythonPath test checks interpreter imports; it does not fully exercise isolated startup dependency discovery. No new coverage is claimed for that scenario.
